### PR TITLE
Refactor modal to make it reusable

### DIFF
--- a/client/src/components/BoardForm.jsx
+++ b/client/src/components/BoardForm.jsx
@@ -1,0 +1,19 @@
+const BoardForm = () => {
+    return (
+        <div className='mb-4'>
+            <label
+                htmlFor='email'
+                className='block text-white-700 font-bold mb-2'
+            >
+                Email:
+                <input
+                    type='email'
+                    id='email'
+                    className='w-full border border-gray-300 p-2 rounded-md'
+                />
+            </label>
+        </div>
+    );
+};
+
+export default BoardForm;

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,0 +1,48 @@
+import {useContext, useEffect} from 'react';
+import {ModalContext} from '../contexts/ModalContext/ModalContext';
+
+const Modal = ({children}) => {
+    const {isModalOpen, handleClose} = useContext(ModalContext);
+
+    useEffect(() => {
+        console.log('Rendered');
+
+        function handleEscapeKey(event) {
+            console.log(event);
+            if (event.code === 'Escape') {
+                handleClose();
+            }
+        }
+        document.addEventListener('keydown', handleEscapeKey);
+
+        // cleanup when unmounting/removing this component
+        return () => {
+            console.log('removed');
+            document.removeEventListener('keydown', handleEscapeKey);
+        };
+    }, [handleClose]);
+
+    return (
+        <dialog className='modal' open={isModalOpen}>
+            <div className='modal-box'>
+                <button
+                    onClick={handleClose}
+                    className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'
+                    type='button'
+                >
+                    x
+                </button>
+                {children}
+            </div>
+            <div
+                className='modal-backdrop bg-slate-400 opacity-50'
+                onClick={handleClose}
+                role='button'
+                tabIndex={0}
+                aria-hidden='true'
+            />
+        </dialog>
+    );
+};
+
+export default Modal;

--- a/client/src/contexts/AuthContext/authContext.jsx
+++ b/client/src/contexts/AuthContext/authContext.jsx
@@ -1,6 +1,6 @@
 import {createContext, useContext, useState, useMemo, useEffect} from 'react';
 import dataService from '../../services/dataService';
-import { useRoutingContext } from '../RoutingContext/routingContext';
+import {useRoutingContext} from '../RoutingContext/routingContext';
 
 // Create a named context
 const AuthContext = createContext();
@@ -39,19 +39,18 @@ const AuthProvider = ({children}) => {
                 password: '12345678',
             });
 
-            setCurrentPage('dashboard')
+            setCurrentPage('dashboard');
             console.log(response);
             setIsAuthenticated(true);
             console.log(isAuthenticated);
         } catch (err) {
             console.log(err);
-            return;
         }
     };
 
     const logout = () => {
         setIsAuthenticated(false);
-        setCurrentPage('landingPage')
+        setCurrentPage('landingPage');
     };
 
     // useMemo is a Hook that lets you cache the result of a calculation between re-renders.

--- a/client/src/features/BoardGrid.jsx
+++ b/client/src/features/BoardGrid.jsx
@@ -1,43 +1,49 @@
-import {useContext} from 'react'
+import {useContext} from 'react';
 import Card from '../components/BoardCard';
-import { ModalContext } from '../contexts/ModalContext/ModalContext';
-import BoardForm from "./BoardForm";
-    
-    const BoardGrid = ({clickedCardId, setClickedCardId}) => {
-      // this should capture an array of objects(boards)
-      const {handleModal, isModalOpen, handleClose} = useContext(ModalContext);
+import {ModalContext} from '../contexts/ModalContext/ModalContext';
+import BoardForm from './BoardForm';
+import Modal from '../components/Modal';
+import Form from '../components/BoardForm';
+
+const BoardGrid = ({clickedCardId, setClickedCardId}) => {
+    // this should capture an array of objects(boards)
+    const {handleModal, isModalOpen, handleClose, handleOpen} =
+        useContext(ModalContext);
     return (
-    <div className='px-6 max-w-7xl mx-auto'>
-        <div className='grid grid-cols-fluid justify-items-center gap-6 '>
-            <Card
-                clickedCardId={clickedCardId}
-                setClickedCardId={setClickedCardId}
-            />
-            <Card
-                clickedCardId={clickedCardId}
-                setClickedCardId={setClickedCardId}
-            />
-            <Card
-                clickedCardId={clickedCardId}
-                setClickedCardId={setClickedCardId}
-            />
-            <Card
-                clickedCardId={clickedCardId}
-                setClickedCardId={setClickedCardId}
-            />
-            <Card
-                clickedCardId={clickedCardId}
-                setClickedCardId={setClickedCardId}
-            />
-            <div>
-              <button type='button' className="btn" onClick={handleModal}>Create New Board</button>
-              {isModalOpen 
-                ? <BoardForm handleClose={handleClose} className="modal-box"/>
-                : null}
+        <div className='px-6 max-w-7xl mx-auto'>
+            <div className='grid grid-cols-fluid justify-items-center gap-6 '>
+                <Card
+                    clickedCardId={clickedCardId}
+                    setClickedCardId={setClickedCardId}
+                />
+                <Card
+                    clickedCardId={clickedCardId}
+                    setClickedCardId={setClickedCardId}
+                />
+                <Card
+                    clickedCardId={clickedCardId}
+                    setClickedCardId={setClickedCardId}
+                />
+                <Card
+                    clickedCardId={clickedCardId}
+                    setClickedCardId={setClickedCardId}
+                />
+                <Card
+                    clickedCardId={clickedCardId}
+                    setClickedCardId={setClickedCardId}
+                />
+                <div>
+                    <button type='button' className='btn' onClick={handleModal}>
+                        Create New Board
+                    </button>
+                </div>
+
+                <Modal>
+                    <Form />
+                </Modal>
             </div>
         </div>
-    </div>
-    )
+    );
 };
 
 export default BoardGrid;

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,7 @@ require('dotenv').config({path: './config/.env'});
 
 const PORT = process.env.SERVER_PORT || 8888;
 const app = express();
-const User = require('./models/User');
+
 
 // connect to database
 connectDB();


### PR DESCRIPTION
## Description

- Refactored modal component to be able to use the same component for when we need to use a modal
- Also made modal accessible (passes es lint accessibility checks)
- Able to either click overlay to exit modal, click the X or use ESC key on keyboard
- Also Prettier formatted some code

To create this modal i daisyUI modal which is a dialog element. 
More info on dialogs here https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog

## Related Issue

-   [x] Is this related to a specific issue? Is so please specify: #57 

## Type of Changes

Use a check for ✓ the following type of changes:

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|   | :sparkles: New feature     |
| ✓    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates


### After

![image](https://github.com/snowballDevs/kandoo/assets/105207353/8ec44dc4-78e1-4e9f-9ddf-9976aed0f4e7)


## Testing Steps / QA Criteria
Went through accessibility checks with ES Lint
Used modal to check for expected beahviour


## Checklist:

-   [x] This PR is up to date with the development branch, and merge conflicts have been resolved
-   [x] My code follows the style guidelines of this project
-   [x] I have executed npm run lint and resolved any outstanding errors. 
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
