### PR TITLE
Slideover interactions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
                 "@dnd-kit/sortable": "^7.0.2",
                 "@dnd-kit/utilities": "^3.2.1",
                 "@headlessui/react": "^1.7.16",
+                "@heroicons/react": "^2.0.18",
                 "@vitejs/plugin-react": "^4.0.0",
                 "axios": "^1.4.0",
                 "daisyui": "^3.1.0",
@@ -854,6 +855,14 @@
             "peerDependencies": {
                 "react": "^16 || ^17 || ^18",
                 "react-dom": "^16 || ^17 || ^18"
+            }
+        },
+        "node_modules/@heroicons/react": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.0.18.tgz",
+            "integrity": "sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==",
+            "peerDependencies": {
+                "react": ">= 16"
             }
         },
         "node_modules/@humanwhocodes/config-array": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
                 "react-dom": "^18.2.0",
                 "react-hook-form": "^7.45.1",
                 "react-icons": "^4.10.1",
+                "react-toastify": "^9.1.3",
                 "vite": "^4.3.2"
             },
             "devDependencies": {
@@ -1424,6 +1425,14 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
+        "node_modules/clsx": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/color-convert": {
             "version": "1.9.3",
@@ -3593,6 +3602,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-toastify": {
+            "version": "9.1.3",
+            "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+            "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+            "dependencies": {
+                "clsx": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": ">=16",
+                "react-dom": ">=16"
             }
         },
         "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.1",
         "react-icons": "^4.10.1",
+        "react-toastify": "^9.1.3",
         "vite": "^4.3.2"
     },
     "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.1",
         "@headlessui/react": "^1.7.16",
+        "@heroicons/react": "^2.0.18",
         "@vitejs/plugin-react": "^4.0.0",
         "axios": "^1.4.0",
         "daisyui": "^3.1.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,7 +17,8 @@ const App = () => {
 
     return (
         <div className='bg-primaryLight min-h-screen'>
-          <ToastContainer  />
+          {/* Toast Container should be stated once in App root */}
+          <ToastContainer  /> 
 
 
             {/* {isAuthenticated ? <Dashboard /> : <LandingPage />} */}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,11 +1,14 @@
 import './App.css';
 import {useState} from 'react';
+import { ToastContainer, toast} from 'react-toastify';
 import {useAuthContext} from './contexts/AuthContext/authContext';
 import {useRoutingContext} from './contexts/RoutingContext/routingContext';
 import LandingPage from './features/LandingPage';
 import Footer from './components/Footer';
 import Dashboard from './features/Dashboard';
 import Workspace from './features/Workspace';
+import 'react-toastify/dist/ReactToastify.css';
+
 
 const App = () => {
     const {isAuthenticated} = useAuthContext();
@@ -14,6 +17,7 @@ const App = () => {
 
     return (
         <div className='bg-primaryLight min-h-screen'>
+          <ToastContainer  />
 
 
             {/* {isAuthenticated ? <Dashboard /> : <LandingPage />} */}

--- a/client/src/components/BoardCard.jsx
+++ b/client/src/components/BoardCard.jsx
@@ -16,13 +16,13 @@ const Card = ({name, desc, id, onDelete, onClick}) => {
             onClick={(e) => onClick(e)}
             id={id}
         >
-            <button
+            {/* <button
                 className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'
                 type='button'
                 onClick={(e) => onDelete(e, id)}
             >
                 x
-            </button>
+            </button> */}
             <div className='flex flex-col gap-4'>
                 <h3 className='font-bold text-xl truncate leading-tight'>
                     {name}

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -20,7 +20,7 @@ const Modal = ({children}) => {
             console.log('removed');
             document.removeEventListener('keydown', handleEscapeKey);
         };
-    }, [handleClose]);
+    }, []);
 
     return (
         <dialog className='modal' open={isModalOpen}>

--- a/client/src/components/dndkanban.jsx
+++ b/client/src/components/dndkanban.jsx
@@ -105,7 +105,7 @@ const defaultTasks = [
 
 const KanbanBoard = ({boardInfo}) => {
     // KANDOO CODE
-    //catagoryStages is an array of Board; Column is the column component
+    // catagoryStages is an array of Board; Column is the column component
     const {handleModal, isModalOpen, handleClose, handleOpen} =
         useContext(ModalContext);
 
@@ -124,7 +124,7 @@ const KanbanBoard = ({boardInfo}) => {
             console.log('Sending Request');
             const response = await dataService.getColumns();
             console.log(response);
-            setColumns(response.data.board.column); //find one board ID
+           setColumns(resonse.data.board.column); // find one board ID
         } catch (err) {
             console.log(err);
         }
@@ -153,7 +153,7 @@ const KanbanBoard = ({boardInfo}) => {
 
     // const { column, tasks } = boardInfo;
 
-    //TUTORIAL
+    // TUTORIAL
     const [columns, setColumns] = useState(defaultCols);
     const columnsId = useMemo(() => columns.map((col) => col.id), [columns]);
     const [tasks, setTasks] = useState(defaultTasks);
@@ -168,7 +168,7 @@ const KanbanBoard = ({boardInfo}) => {
         })
     );
 
-    //TODO
+    // TODO
     function createTask(columnId) {
         const newTask = {
             _id: generateId(),
@@ -227,7 +227,7 @@ const KanbanBoard = ({boardInfo}) => {
 
         if (event.active.data.current?.type === 'Task') {
             setActiveTask(event.active.data.current.task);
-            return;
+            
         }
     }
 

--- a/client/src/components/dndtaskcard.jsx
+++ b/client/src/components/dndtaskcard.jsx
@@ -8,7 +8,7 @@ import TaskModal from "./TaskModal";
 import Task from './Task';
 
 const TaskCard = ({task, taskName, taskPriority, taskComment, taskDetail, deleteTask, updateTask}) => {
-    const {handleModal, isModalOpen, handleClose, handleOpen} =
+    const {handleModal, isModalOpen, handleClose, handleOpen, isSlideOverOpen, setIsSlideOverOpen, handleSlideOver} =
         useContext(ModalContext);
 
     const [mouseIsOver, setMouseIsOver] = useState(false);
@@ -97,7 +97,7 @@ const TaskCard = ({task, taskName, taskPriority, taskComment, taskDetail, delete
             style={style}
             {...attributes}
             {...listeners}
-            onClick={toggleEditMode}
+            onClick={() => handleSlideOver()}
             className='bg-secondaryLight p-2.5 h-[100px] min-h-[100px] items-center flex text-left rounded-xl hover:ring-2 hover:ring-inset hover:ring-pinkLight cursor-grab relative task'
             onMouseEnter={() => {
                 setMouseIsOver(true);
@@ -108,14 +108,13 @@ const TaskCard = ({task, taskName, taskPriority, taskComment, taskDetail, delete
         >
             <p
                 className='my-auto h-[90%] w-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap text-white'
-                onClick={handleModal}
             >
                 {' '}
                 {/* slide right */}
                 {task.content}
             </p>
 
-            <TaskModal>
+            {/* <TaskModal>
                 <Task
                     key={task.id}
                     taskName={taskName}
@@ -125,7 +124,7 @@ const TaskCard = ({task, taskName, taskPriority, taskComment, taskDetail, delete
                     deleteTask={deleteTask}
                     updateTask={updateTask}
                 />
-            </TaskModal>
+            </TaskModal> */}
 
             {mouseIsOver && (
                 <button

--- a/client/src/contexts/ModalContext/ModalContext.jsx
+++ b/client/src/contexts/ModalContext/ModalContext.jsx
@@ -13,6 +13,7 @@ const ModalProvider = ({children}) => {
 
   const handleSlideOver = () => {
     setIsSlideOverOpen(prevState => !prevState)
+    
   }
 
   const modalValue = useMemo(

--- a/client/src/contexts/ModalContext/ModalContext.jsx
+++ b/client/src/contexts/ModalContext/ModalContext.jsx
@@ -1,15 +1,23 @@
 //  purpose of this context is to pass modal abilities into other components throughout the app
-import {createContext, useMemo} from 'react'
+import {createContext, useMemo, useContext, useState} from 'react'
 import useModal from '../../hooks/useModal'
 
 const ModalContext = createContext();
 
+// Custom hook to allow components to consume the context(authentication)
+const useModalContext = () => useContext(ModalContext);
+
 const ModalProvider = ({children}) => {
   const {isModalOpen, handleModal, handleClose, handleOpen, setIsModalOpen} = useModal();
+  const [isSlideOverOpen, setIsSlideOverOpen] = useState(false)
+
+  const handleSlideOver = () => {
+    setIsSlideOverOpen(prevState => !prevState)
+  }
 
   const modalValue = useMemo(
-    () => ({isModalOpen, setIsModalOpen, handleModal, handleClose, handleOpen}),
-    [isModalOpen] 
+    () => ({isModalOpen, setIsModalOpen, handleModal, handleClose, handleOpen, isSlideOverOpen, setIsSlideOverOpen, handleSlideOver}),
+    [isModalOpen, isSlideOverOpen] 
   )
   
   return(
@@ -19,4 +27,4 @@ const ModalProvider = ({children}) => {
   ) 
 }
 
-export {ModalContext, ModalProvider}
+export {useModalContext, ModalProvider, ModalContext}

--- a/client/src/features/BoardConfirmDelete.jsx
+++ b/client/src/features/BoardConfirmDelete.jsx
@@ -1,0 +1,46 @@
+import {Fragment, useState} from 'react';
+import {ExclamationTriangleIcon, XMarkIcon} from '@heroicons/react/24/outline';
+
+const BoardConfirmDelete = ({closeModal, deleteBoard, boardId}) => {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <div>
+            <div className='sm:flex sm:items-start'>
+                <div className='mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10'>
+                    <ExclamationTriangleIcon
+                        className='h-6 w-6 text-red-600'
+                        aria-hidden='true'
+                    />
+                </div>
+
+                <div className='mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left'>
+                    <h3
+                        className='text-base font-semibold leading-6 text-gray-900'
+                    >
+                        Delete Board
+                    </h3>
+                    <div className='mt-2'>
+                        <p className='text-sm text-gray-500'>
+                            Are you sure you want to delete this board? All of
+                            your tasks, comments, and columns will be
+                            permanently removed from our servers forever. This
+                            action cannot be undone.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div className='mt-5 sm:mt-4 sm:flex sm:flex-row-reverse'>
+                <button
+                    type='button'
+                    className='inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto'
+                    onClick={() => deleteBoard(boardId)}
+                >
+                    Delete
+                </button>
+                
+            </div>
+        </div>
+    );
+};
+export default BoardConfirmDelete;

--- a/client/src/features/BoardGrid.jsx
+++ b/client/src/features/BoardGrid.jsx
@@ -83,7 +83,7 @@ const BoardGrid = ({clickedCardId, setClickedCardId}) => {
                         name={board.boardName}
                         desc={board.description}
                         id={board._id}
-                        onDelete={onDelete}
+                        // onDelete={onDelete}
                     />
                 ))}
 

--- a/client/src/features/BoardGrid.jsx
+++ b/client/src/features/BoardGrid.jsx
@@ -8,6 +8,7 @@ import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import dataService from '../services/dataService';
 import JoinBoardForm from './JoinBoardForm';
 
+
 const BoardGrid = ({clickedCardId, setClickedCardId}) => {
     // this should capture an array of objects(boards)
     const {handleModal, isModalOpen, handleClose, handleOpen} =

--- a/client/src/features/BoardGrid.jsx
+++ b/client/src/features/BoardGrid.jsx
@@ -1,12 +1,12 @@
 import {useContext, useEffect, useState} from 'react';
 import Card from '../components/BoardCard';
 import {ModalContext} from '../contexts/ModalContext/ModalContext';
-import BoardForm from './BoardForm';
 import Modal from '../components/Modal';
 import CreateBoardForm from '../components/CreateBoardForm';
 import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
 import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import dataService from '../services/dataService';
+import JoinBoardForm from './JoinBoardForm';
 
 const BoardGrid = ({clickedCardId, setClickedCardId}) => {
     // this should capture an array of objects(boards)
@@ -18,6 +18,12 @@ const BoardGrid = ({clickedCardId, setClickedCardId}) => {
     const {setCurrentPage} = useRoutingContext();
 
     const [boards, setBoards] = useState([]);
+    const [displayedForm, setDisplayedForm] = useState(null)
+
+    const handleDisplayedForm = (formToDisplay) => {
+      setDisplayedForm(formToDisplay)
+      handleOpen();
+    }
 
     useEffect(() => {
         getBoards();
@@ -54,12 +60,20 @@ const BoardGrid = ({clickedCardId, setClickedCardId}) => {
             <div className='flex justify-center pb-8'>
                 <button
                     type='button'
-                    className='btn bg-flashy text-primaryLight border-primaryLight'
-                    onClick={handleModal}
+                    className='btn bg-tertiaryLight text-primaryLight border-tertiaryLight hover:bg-successLight hover:text-secondaryLight'
+                    onClick={() => handleDisplayedForm('create')}
                 >
                     Create New Board
                 </button>
+                <button 
+                  className='btn bg-secondaryLight text-primaryLight hover:bg-fuchsia-500 ml-3' 
+                  type='button'
+                  onClick={() => handleDisplayedForm('join')}
+                >
+                  Join Board
+                </button>
             </div>
+            
             <div className='grid grid-cols-fluid justify-items-center gap-6 '>
                 {boards.map((board) => (
                     <Card
@@ -73,7 +87,8 @@ const BoardGrid = ({clickedCardId, setClickedCardId}) => {
                 ))}
 
                 <Modal>
-                    <CreateBoardForm />
+                  {displayedForm === 'create' && <CreateBoardForm />}
+                  {displayedForm === 'join' && <JoinBoardForm />}
                 </Modal>
             </div>
         </div>

--- a/client/src/features/JoinBoardForm.jsx
+++ b/client/src/features/JoinBoardForm.jsx
@@ -1,4 +1,5 @@
 import {useState, useContext} from 'react'
+import { toast } from 'react-toastify';
 import dataService from '../services/dataService';
 import {ModalContext} from '../contexts/ModalContext/ModalContext'
 import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
@@ -40,9 +41,38 @@ const handleSubmit = async (event) => {
           setSelectedBoard(board);
           setCurrentPage('workspace');
           handleClose();
-      }
+      } 
+      
   } catch (error) {
-      console.error('Error: ', error.message);
+      // handle error
+      console.error('Error on joining board: ', error.message);
+      if(error.response) {
+        console.log(error.response)
+
+        if(error.response.status === 400) {
+          toast.error('Already joined this board!', {
+            position: "top-center",
+            autoClose: 3000,
+            hideProgressBar: false,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+            theme: "colored",
+            })
+        } else {
+          toast.error('Invalid Board ID', {
+            position: "top-center",
+            autoClose: 3000,
+            hideProgressBar: false,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+            theme: "colored",
+            } )
+        }
+      }
   }
 };
 

--- a/client/src/features/JoinBoardForm.jsx
+++ b/client/src/features/JoinBoardForm.jsx
@@ -1,0 +1,99 @@
+import {useState, useContext} from 'react'
+import dataService from '../services/dataService';
+import {ModalContext} from '../contexts/ModalContext/ModalContext'
+import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
+import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
+
+const JoinBoardForm = () => {
+  const {handleModal, isModalOpen, handleClose, handleOpen} =
+        useContext(ModalContext);
+
+  const [formData, setFormData] = useState({
+    boardId:'',
+  })
+
+  const {setCurrentPage} = useRoutingContext();
+  const {setSelectedBoard} = useSelectedBoardContext();
+
+  const handleChange = (event) => {
+    const {name, value} = event.target;
+    setFormData((prevFormData) => ({
+        ...prevFormData,
+        [name]: value,
+    }));
+    console.log(event.target.value);
+};
+
+const handleSubmit = async (event) => {
+  // prevent refreshing the form
+  event.preventDefault();
+  try {
+      
+      const response = await dataService.joinBoard(formData);
+      console.log(response);
+      // handle response
+      if (response.status >= 200 && response.status < 300) {
+          console.log('Request Successful', response);
+          // board object is being passed back to client so that we can navigate to the board on joining board
+          const {board} = response.data;
+          
+          setSelectedBoard(board);
+          setCurrentPage('workspace');
+          handleClose();
+      }
+  } catch (error) {
+      console.error('Error: ', error.message);
+  }
+};
+
+  return (
+    <div>
+            <div className='flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8'>
+                <div className='sm:mx-auto sm:w-full sm:max-w-sm'>
+                    <img
+                        className='mx-auto w-32'
+                        src='/KandooLogoW.png'
+                        alt='Your Company'
+                    />
+                    <h2 className='mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900'>
+                        The start of something special
+                    </h2>
+                </div>
+
+                <div className='mt-6 sm:mx-auto sm:w-full sm:max-w-sm'>
+                    <form className='space-y-2' onSubmit={handleSubmit}>
+                        <div>
+                            <label
+                                htmlFor='boardId'
+                                className='block text-sm font-medium leading-6 text-gray-900'
+                            >
+                              Board ID
+                              <div className='mt-2'>
+                                <input
+                                    id='boardId'
+                                    name='boardId'
+                                    type='text'
+                                    onChange={handleChange}
+                                    required
+                                    className='block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
+                                />
+                            </div>
+                            </label>
+                            
+                        </div>
+                        <div>
+                            <button
+                                type='submit'
+                                className='flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
+                            >
+                                Join Board
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+  )
+}
+
+export default JoinBoardForm

--- a/client/src/features/Workspace.jsx
+++ b/client/src/features/Workspace.jsx
@@ -3,6 +3,7 @@ import Header from '../components/Header';
 import WorkspaceHeader from './WorkspaceHeader';
 import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import KanbanBoard from '../components/dndkanban';
+import WorkspaceSlideOver from './WorkspaceSlideOver';
 
 const Workspace = () => {
     const {selectedBoard} = useSelectedBoardContext();
@@ -15,6 +16,7 @@ const Workspace = () => {
             <Header />
             <WorkspaceHeader boardInfo={boardInfo} />
             <KanbanBoard boardInfo={boardInfo} />
+            <WorkspaceSlideOver boardInfo={boardInfo}/>
         </div>
     );
 };

--- a/client/src/features/WorkspaceHeader.jsx
+++ b/client/src/features/WorkspaceHeader.jsx
@@ -1,3 +1,4 @@
+import { useState, useContext } from 'react'
 import {MdDelete, MdModeEdit, MdFileCopy} from 'react-icons/md';
 import {ToastContainer, toast} from 'react-toastify';
 import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
@@ -5,15 +6,28 @@ import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import dataService from '../services/dataService';
 import formatDate from '../utils/formatDate';
 import 'react-toastify/dist/ReactToastify.css';
+import BoardConfirmDelete from './BoardConfirmDelete'
+import {ModalContext} from '../contexts/ModalContext/ModalContext';
+import Modal from '../components/Modal'
 
 const WorkspaceHeader = ({boardInfo}) => {
     const {setCurrentPage} = useRoutingContext();
+    const {handleModal, isModalOpen, handleClose, handleOpen} =
+        useContext(ModalContext);
+
+    const [displayedModal, setDisplayedModal] = useState(null)
+
+    const handleDisplayedModal = (modalContent) => {
+      setDisplayedModal(modalContent)
+      handleOpen();
+    }
 
     const deleteProject = async (id) => {
         try {
             const deletedProject = await dataService.deleteBoard(id);
             console.log(deleteProject);
             setCurrentPage('dashboard');
+            handleClose();
         } catch (err) {
             console.log(err);
         }
@@ -67,12 +81,15 @@ const WorkspaceHeader = ({boardInfo}) => {
 
                     <button
                         type='button'
-                        onClick={() => deleteProject(boardInfo._id)}
+                        onClick={() =>handleDisplayedModal('confirmDelete')}
                         className='flex items-center justify-center font-semibold hover:bg-red-700 text-gray-100 bg-dangerLight dark:hover:bg-red-500 dark:text-gray-100 rounded px-2 w-min-content py-2'
                     ><MdDelete className='text-xl' />
                     </button>
                 </div>
             </div>
+            <Modal>
+              <BoardConfirmDelete closeModal={handleClose} deleteBoard={deleteProject} boardId={boardInfo._id}/>
+            </Modal>
         </div>
     );
 };

--- a/client/src/features/WorkspaceHeader.jsx
+++ b/client/src/features/WorkspaceHeader.jsx
@@ -1,8 +1,10 @@
 import {MdDelete, MdModeEdit, MdFileCopy} from 'react-icons/md';
+import {ToastContainer, toast} from 'react-toastify';
 import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
 import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import dataService from '../services/dataService';
 import formatDate from '../utils/formatDate';
+import 'react-toastify/dist/ReactToastify.css';
 
 const WorkspaceHeader = ({boardInfo}) => {
     const {setCurrentPage} = useRoutingContext();
@@ -21,6 +23,16 @@ const WorkspaceHeader = ({boardInfo}) => {
       try {
         console.log('id to be copied: ',id)
         await navigator.clipboard.writeText(id)
+        toast.success("Board ID Copied!", {
+          position: "top-center",
+          autoClose: 750,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress:undefined,
+          theme: "colored",
+        })
       } catch (error) {
         console.error(error)
       }
@@ -47,6 +59,7 @@ const WorkspaceHeader = ({boardInfo}) => {
                     <button type='button' className='flex items-center justify-center font-semibold bg-gray-600 text-gray-100 rounded w-min-content py-2 px-2 hover:bg-gray-500' onClick={() => copyID(boardInfo._id)}>
                       <MdFileCopy className='mr-2' /> Copy ID
                     </button>
+                    
                     <button type='button' className='flex items-center justify-center font-semibold dark:bg-gray-900 bg-tertiaryLight text-gray-100 dark:bg-gray-600 dark:hover:bg-blue-500 dark:text-gray-100 rounded w-min-content py-2 px-2'>
                         <MdModeEdit className='text-xl mr-2' />
                         Edit

--- a/client/src/features/WorkspaceHeader.jsx
+++ b/client/src/features/WorkspaceHeader.jsx
@@ -73,7 +73,7 @@ const WorkspaceHeader = ({boardInfo}) => {
                     <button type='button' className='flex items-center justify-center font-semibold bg-gray-600 text-gray-100 rounded w-min-content py-2 px-2 hover:bg-gray-500' onClick={() => copyID(boardInfo._id)}>
                       <MdFileCopy className='mr-2' /> Copy ID
                     </button>
-                    
+
                     <button type='button' className='flex items-center justify-center font-semibold dark:bg-gray-900 bg-tertiaryLight text-gray-100 dark:bg-gray-600 dark:hover:bg-blue-500 dark:text-gray-100 rounded w-min-content py-2 px-2'>
                         <MdModeEdit className='text-xl mr-2' />
                         Edit

--- a/client/src/features/WorkspaceHeader.jsx
+++ b/client/src/features/WorkspaceHeader.jsx
@@ -1,4 +1,4 @@
-import {MdDelete, MdModeEdit} from 'react-icons/md';
+import {MdDelete, MdModeEdit, MdFileCopy} from 'react-icons/md';
 import {useRoutingContext} from '../contexts/RoutingContext/routingContext';
 import {useSelectedBoardContext} from '../contexts/BoardContext/boardContext';
 import dataService from '../services/dataService';
@@ -16,6 +16,15 @@ const WorkspaceHeader = ({boardInfo}) => {
             console.log(err);
         }
     };
+
+    const copyID = async(id) => {
+      try {
+        console.log('id to be copied: ',id)
+        await navigator.clipboard.writeText(id)
+      } catch (error) {
+        console.error(error)
+      }
+    }
 
     return (
         <div>
@@ -35,16 +44,19 @@ const WorkspaceHeader = ({boardInfo}) => {
                     </p>
                 </div>
                 <div className='flex gap-5 mt-5 md:mt-0 justify-end'>
-                    <button type='button' className='flex items-center justify-center font-semibold dark:bg-gray-900 bg-tertiaryLight text-gray-100 dark:bg-gray-600 dark:hover:bg-blue-500 dark:text-gray-100 rounded w-32 py-2 px-2'>
+                    <button type='button' className='flex items-center justify-center font-semibold bg-gray-600 text-gray-100 rounded w-min-content py-2 px-2 hover:bg-gray-500' onClick={() => copyID(boardInfo._id)}>
+                      <MdFileCopy className='mr-2' /> Copy ID
+                    </button>
+                    <button type='button' className='flex items-center justify-center font-semibold dark:bg-gray-900 bg-tertiaryLight text-gray-100 dark:bg-gray-600 dark:hover:bg-blue-500 dark:text-gray-100 rounded w-min-content py-2 px-2'>
                         <MdModeEdit className='text-xl mr-2' />
+                        Edit
                     </button>
 
                     <button
                         type='button'
                         onClick={() => deleteProject(boardInfo._id)}
-                        className='flex items-center justify-center font-semibold hover:bg-red-700 text-gray-100 bg-dangerLight dark:hover:bg-red-500 dark:text-gray-100 rounded px-3 '
-                    >
-                        <MdDelete className='text-xl mr-2' />
+                        className='flex items-center justify-center font-semibold hover:bg-red-700 text-gray-100 bg-dangerLight dark:hover:bg-red-500 dark:text-gray-100 rounded px-2 w-min-content py-2'
+                    ><MdDelete className='text-xl' />
                     </button>
                 </div>
             </div>

--- a/client/src/features/WorkspaceSlideOver.jsx
+++ b/client/src/features/WorkspaceSlideOver.jsx
@@ -42,7 +42,7 @@ const team = [
 ];
 const WorkspaceSlideOver = (boardInfo) => {
     const {isSlideOverOpen, setIsSlideOverOpen} = useModalContext();
-
+    console.log(boardInfo)
     return (
         <Transition.Root show={isSlideOverOpen} as={Fragment}>
             <Dialog

--- a/client/src/features/WorkspaceSlideOver.jsx
+++ b/client/src/features/WorkspaceSlideOver.jsx
@@ -1,0 +1,266 @@
+import {Fragment, useState} from 'react';
+import {Dialog, Transition} from '@headlessui/react';
+import {XMarkIcon} from '@heroicons/react/24/outline';
+import {useModalContext} from '../contexts/ModalContext/ModalContext';
+
+const team = [
+    {
+        name: 'Tom Cook',
+        email: 'tom.cook@example.com',
+        href: '#',
+        imageUrl:
+            'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+    {
+        name: 'Whitney Francis',
+        email: 'whitney.francis@example.com',
+        href: '#',
+        imageUrl:
+            'https://images.unsplash.com/photo-1517365830460-955ce3ccd263?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+    {
+        name: 'Leonard Krasner',
+        email: 'leonard.krasner@example.com',
+        href: '#',
+        imageUrl:
+            'https://images.unsplash.com/photo-1519345182560-3f2917c472ef?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+    {
+        name: 'Floyd Miles',
+        email: 'floyd.miles@example.com',
+        href: '#',
+        imageUrl:
+            'https://images.unsplash.com/photo-1463453091185-61582044d556?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+    {
+        name: 'Emily Selman',
+        email: 'emily.selman@example.com',
+        href: '#',
+        imageUrl:
+            'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+    },
+];
+const WorkspaceSlideOver = (boardInfo) => {
+    const {isSlideOverOpen, setIsSlideOverOpen} = useModalContext();
+
+    return (
+        <Transition.Root show={isSlideOverOpen} as={Fragment}>
+            <Dialog
+                as='div'
+                className='relative z-10'
+                onClose={() => setIsSlideOverOpen(false)}
+            >
+                <Transition.Child
+                    as={Fragment}
+                    enter='ease-in-out duration-500'
+                    enterFrom='opacity-0'
+                    enterTo='opacity-100'
+                    leave='ease-in-out duration-500'
+                    leaveFrom='opacity-100'
+                    leaveTo='opacity-0'
+                >
+                    <div className='fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity' />
+                </Transition.Child>
+
+                <div className='fixed inset-0 overflow-hidden'>
+                    <div className='absolute inset-0 overflow-hidden'>
+                        <div className='pointer-events-none fixed inset-y-0 right-0 flex max-w-full pl-10'>
+                            <Transition.Child
+                                as={Fragment}
+                                enter='transform transition ease-in-out duration-500 sm:duration-700'
+                                enterFrom='translate-x-full'
+                                enterTo='translate-x-0'
+                                leave='transform transition ease-in-out duration-500 sm:duration-700'
+                                leaveFrom='translate-x-0'
+                                leaveTo='translate-x-full'
+                            >
+                                <Dialog.Panel className='pointer-events-auto w-screen max-w-2xl'>
+                                    <form className='flex h-full flex-col overflow-y-scroll bg-white shadow-xl'>
+                                        <div className='flex-1'>
+                                            {/* Header */}
+                                            <div className='bg-gray-50 px-4 py-6 sm:px-6'>
+                                                <div className='flex items-start justify-between space-x-3'>
+                                                    <div className='space-y-1'>
+                                                        <Dialog.Title className='text-base font-semibold leading-6 text-gray-900'>
+                                                            New project
+                                                        </Dialog.Title>
+                                                        <p className='text-sm text-gray-500'>
+                                                            Get started by
+                                                            filling in the
+                                                            information below to
+                                                            create your new
+                                                            project.
+                                                        </p>
+                                                    </div>
+                                                    <div className='flex h-7 items-center'>
+                                                        <button
+                                                            type='button'
+                                                            className='relative text-gray-400 hover:text-gray-500'
+                                                            onClick={() =>
+                                                                setIsSlideOverOpen(
+                                                                    false
+                                                                )
+                                                            }
+                                                        >
+                                                            <span className='absolute -inset-2.5' />
+                                                            <span className='sr-only'>
+                                                                Close panel
+                                                            </span>
+                                                            <XMarkIcon
+                                                                className='h-6 w-6'
+                                                                aria-hidden='true'
+                                                            />
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            {/* Divider container */}
+                                            <div className='space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0'>
+                                                {/* Project name */}
+                                                <div className='space-y-2 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5'>
+                                                    <div>
+                                                        <label
+                                                            htmlFor='project-name'
+                                                            className='block text-sm font-medium leading-6 text-gray-900 sm:mt-1.5'
+                                                        >
+                                                            Task Name
+                                                        </label>
+                                                    </div>
+                                                    <div className='sm:col-span-2'>
+                                                        <input
+                                                            type='text'
+                                                            name='project-name'
+                                                            id='project-name'
+                                                            className='block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                {/* Project description */}
+                                                <div className='space-y-2 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5'>
+                                                    <div>
+                                                        <label
+                                                            htmlFor='project-description'
+                                                            className='block text-sm font-medium leading-6 text-gray-900 sm:mt-1.5'
+                                                        >
+                                                            Description
+                                                        </label>
+                                                    </div>
+                                                    <div className='sm:col-span-2'>
+                                                        <textarea
+                                                            id='project-description'
+                                                            name='project-description'
+                                                            rows={3}
+                                                            className='block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
+                                                            defaultValue=''
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                <div>
+                                                    <h3 className='font-medium text-gray-900'>
+                                                        Description
+                                                    </h3>
+                                                    <div className='mt-2 flex items-center justify-between'>
+                                                        <p className='text-sm italic text-gray-500'>
+                                                            Add a description to
+                                                            this image.
+                                                        </p>
+                                                        <button
+                                                            type='button'
+                                                            className='relative -mr-2 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+                                                        >
+                                                            <span className='absolute -inset-1.5' />
+                                                            {/* <PencilIcon className="h-5 w-5" aria-hidden="true" /> */}
+                                                            <span className='sr-only'>
+                                                                Add description
+                                                            </span>
+                                                        </button>
+                                                    </div>
+                                                </div>
+
+                                                {/* Team members */}
+                                                <div className='space-y-2 px-4 sm:grid sm:grid-cols-3 sm:items-center sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5'>
+                                                    <div>
+                                                        <h3 className='text-sm font-medium leading-6 text-gray-900'>
+                                                            Team Members
+                                                        </h3>
+                                                    </div>
+                                                    <div className='sm:col-span-2'>
+                                                        <div className='flex space-x-2'>
+                                                            {team.map(
+                                                                (person) => (
+                                                                    <a
+                                                                        key={
+                                                                            person.email
+                                                                        }
+                                                                        href={
+                                                                            person.href
+                                                                        }
+                                                                        className='flex-shrink-0 rounded-full hover:opacity-75'
+                                                                    >
+                                                                        <img
+                                                                            className='inline-block h-8 w-8 rounded-full'
+                                                                            src={
+                                                                                person.imageUrl
+                                                                            }
+                                                                            alt={
+                                                                                person.name
+                                                                            }
+                                                                        />
+                                                                    </a>
+                                                                )
+                                                            )}
+
+                                                            <button
+                                                                type='button'
+                                                                className='relative inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border-2 border-dashed border-gray-200 bg-white text-gray-400 hover:border-gray-300 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2'
+                                                            >
+                                                                <span className='absolute -inset-2' />
+                                                                <span className='sr-only'>
+                                                                    Add team
+                                                                    member
+                                                                </span>
+                                                                {/* <PlusIcon className="h-5 w-5" aria-hidden="true" /> */}
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        {/* Action buttons */}
+                                        <div className='flex-shrink-0 border-t border-gray-200 px-4 py-5 sm:px-6'>
+                                            <div className='flex justify-end space-x-3'>
+                                                <button
+                                                    type='button'
+                                                    className='rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50'
+                                                    onClick={() =>
+                                                        setIsSlideOverOpen(
+                                                            false
+                                                        )
+                                                    }
+                                                >
+                                                    Cancel
+                                                </button>
+                                                <button
+                                                    type='submit'
+                                                    className='inline-flex justify-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600'
+                                                >
+                                                    Create
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </form>
+                                </Dialog.Panel>
+                            </Transition.Child>
+                        </div>
+                    </div>
+                </div>
+            </Dialog>
+        </Transition.Root>
+    );
+};
+
+export default WorkspaceSlideOver;

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -20,7 +20,7 @@ function DataService() {
 
     this.createBoard = (data) => instance.post(`/boards`, data);
 
-    this.joinBoard = (data) => instance.post('/joinBoard', data); 
+    this.joinBoard = (data) => instance.post('/boards/joinBoard', data); 
 
     this.deleteBoard = (boardId) => instance.delete(`/boards/${boardId}`);
 

--- a/client/src/services/dataService.js
+++ b/client/src/services/dataService.js
@@ -20,6 +20,8 @@ function DataService() {
 
     this.createBoard = (data) => instance.post(`/boards`, data);
 
+    this.joinBoard = (data) => instance.post('/joinBoard', data); 
+
     this.deleteBoard = (boardId) => instance.delete(`/boards/${boardId}`);
 
     // Column

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
     theme: {
         extend: {
             gridTemplateColumns: {
-                fluid: 'repeat(auto-fit, minmax(320px, 1fr))',
+                fluid: 'repeat(auto-fill, minmax(300px, 1fr))',
             },
             colors: {
                 primaryLight: '#e9e9e5',

--- a/server/controllers/boardsController.js
+++ b/server/controllers/boardsController.js
@@ -56,32 +56,28 @@ module.exports = {
         }
     },
 
-    joinBoard: async (req, res) => {
-        try {
-            const {boardId} = req.body;
-            const user = req.user.id;
-            const board = await Board.findById(boardId);
+joinBoard: async (req, res) => {
+    try {
+        const { boardId } = req.body;
+        const userId = req.user.id;
 
-            if (!board) {
-                console.log('board not found');
-                return res.status(404).json({message: 'Board not found'});
-            }
-
-            if (board.users.includes(user)) {
-                return res
-                    .status(400)
-                    .json({message: 'User is already a member of the board'});
-            }
-
-            board.users.push(user);
-            await board.save();
-
-            return res.json({message: "User successfully joined the board"})
-
-        } catch (error) {
-            console.log('Error joining a board: ', error);
+        const board = await Board.findById(boardId);
+        if (!board) {
+            return res.status(404).json({ message: 'Board not found' });
         }
-    },
+
+        if (board.users.includes(userId)) {
+            return res.status(400).json({ message: 'User is already a member of the board' });
+        }
+
+        board.users.push(userId);
+        await board.save();
+
+        return res.json({ message: 'User successfully joined the board' });
+    } catch (error) {
+        console.log('Error joining a board:', error);
+    }
+},
 
     // to delete a board on dashboard
     deleteBoard: async (req, res) => {

--- a/server/controllers/boardsController.js
+++ b/server/controllers/boardsController.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-const {Board, Task} = require('../models/Board');
+const {Board} = require('../models/Board');
 
 module.exports = {
     // used on the dashboard to get all the boards
@@ -53,6 +53,33 @@ module.exports = {
             res.json({board});
         } catch (error) {
             console.error(error);
+        }
+    },
+
+    joinBoard: async (req, res) => {
+        try {
+            const {boardId} = req.body;
+            const user = req.user.id;
+            const board = await Board.findById(boardId);
+
+            if (!board) {
+                console.log('board not found');
+                return res.status(404).json({message: 'Board not found'});
+            }
+
+            if (board.users.includes(user)) {
+                return res
+                    .status(400)
+                    .json({message: 'User is already a member of the board'});
+            }
+
+            board.users.push(user);
+            await board.save();
+
+            return res.json({message: "User successfully joined the board"})
+
+        } catch (error) {
+            console.log('Error joining a board: ', error);
         }
     },
 

--- a/server/controllers/boardsController.js
+++ b/server/controllers/boardsController.js
@@ -73,7 +73,8 @@ joinBoard: async (req, res) => {
         board.users.push(userId);
         await board.save();
 
-        return res.json({ message: 'User successfully joined the board' });
+        // Need to ensure that we are sending back the board so that the user can automatically open the board on joining
+        return res.json({board, message: 'User successfully joined the board' });
     } catch (error) {
         console.log('Error joining a board:', error);
     }

--- a/server/routes/boards.js
+++ b/server/routes/boards.js
@@ -9,6 +9,10 @@ router.route('/')
       .get(boardsController.getAllBoards)
       .post(ensureAuth, boardsController.createBoard)
 
+// Joining a Board with BoardId
+router.route('/joinBoard')
+      .post(boardsController.joinBoard)
+
 // Delete a board
 router.route('/:boardId')
       .delete(ensureAuth, boardsController.deleteBoard)


### PR DESCRIPTION
## Description
This PR would clean up the slide-over interactions so that it does not open on render and will slide over (pun intended) when clicking on a task on the kanban board.

It also adds the slideover and starts on the slideover description

## Type of Changes

Use a check for ✓ the following type of changes:

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

On render, the modal and the slideover overlap with one another. 



### After

![image](https://github.com/snowballDevs/kandoo/assets/52391491/d8a38b46-b51c-49f0-aa17-6295d0d09011)


## Checklist:

-   [x] This PR is up to date with the development branch, and merge conflicts have been resolved
-   [x] My code follows the style guidelines of this project
-   [ ] I have executed npm run lint and resolved any outstanding errors. 
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
