### PR TITLE
added additional check if not board owner when deleting board

### DIFF
--- a/client/src/features/WorkspaceHeader.jsx
+++ b/client/src/features/WorkspaceHeader.jsx
@@ -24,10 +24,25 @@ const WorkspaceHeader = ({boardInfo}) => {
 
     const deleteProject = async (id) => {
         try {
-            const deletedProject = await dataService.deleteBoard(id);
-            console.log(deleteProject);
-            setCurrentPage('dashboard');
-            handleClose();
+            const data = await dataService.getUser();
+            const user = data.data.user._id
+            if(user === boardInfo.createdBy) {
+              const deletedProject = await dataService.deleteBoard(id);
+              console.log(deletedProject);
+              setCurrentPage('dashboard');
+              handleClose();
+            } else {
+              toast.error("You don't have permission to delete this board", {
+                position: "top-center",
+                autoClose: 750,
+                hideProgressBar: false,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+                theme: "colored",
+              })
+            }
         } catch (err) {
             console.log(err);
         }


### PR DESCRIPTION
## Description
Ensures that boards can't be deleted if the user isn't the board owner. Notification appears as seen below. 

## Related Issue

-   [ ] Is this related to a specific issue? Is so please specify: closes #96 

## Type of Changes

Use a check for ✓ the following type of changes:

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
Regardless of whether the user is the board owner or not, they are able to delete any board.

### After
Notification appears when you aren't the board owner and you are trying to delete the board:
![image](https://github.com/snowballDevs/kandoo/assets/52391491/2919e1db-689b-40c5-8f44-a3d87440f4bb)



## Checklist:

-   [ ] This PR is up to date with the development branch, and merge conflicts have been resolved
-   [x] My code follows the style guidelines of this project
-   [x] I have executed npm run lint and resolved any outstanding errors. 
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [] My changes generate no new warnings
